### PR TITLE
인증 서버 호출 커넥션 재사용 및 타임아웃 적용

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,16 +4,25 @@ import {
   OnModuleInit,
   UnauthorizedException,
 } from '@nestjs/common';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import * as jwt from 'jsonwebtoken';
 import { MemberInfo } from '../chat/dto/chat-member-info.dto';
 import { LoggingUtil } from '../common/logging.util';
 import { RedisService } from '../redis/redis.service';
 
+const SPRING_REQUEST_TIMEOUT_MS = 5000;
+
 @Injectable()
 export class AuthService implements OnModuleInit {
   private jwtSecret: string;
   private springUrl: string;
+  private readonly httpClient: AxiosInstance = axios.create({
+    timeout: SPRING_REQUEST_TIMEOUT_MS,
+    httpAgent: new HttpAgent({ keepAlive: true }),
+    httpsAgent: new HttpsAgent({ keepAlive: true }),
+  });
 
   constructor(private readonly redisService: RedisService) {}
 
@@ -79,7 +88,7 @@ export class AuthService implements OnModuleInit {
     }
 
     try {
-      const response = await axios.get(`${this.springUrl}/api/auth`, {
+      const response = await this.httpClient.get(`${this.springUrl}/api/auth`, {
         headers: { Authorization: token },
       });
 


### PR DESCRIPTION
## 💡 배경 및 개요

소켓 연결 인증 과정에서 캐시가 없을 때마다 Spring 인증 서버(`/api/auth`)를 호출하는데, 매 요청마다 새로운 TCP(+TLS) 커넥션을 맺어 불필요한 지연이 발생하고 있었습니다. 또한 요청 타임아웃이 설정되어 있지 않아 Spring 서버 응답이 지연될 경우 커넥션이 무한정 점유될 위험이 있었습니다.

## 📃 작업내용

- `AuthService`에 keep-alive 옵션이 적용된 전용 axios 인스턴스를 추가하여 Spring 인증 서버 호출 시 TCP 커넥션을 재사용하도록 개선하였습니다.
- Spring 인증 서버 호출에 5초 타임아웃을 추가하여 응답 지연 시 커넥션이 무한정 점유되지 않도록 하였습니다.

## 🙋‍♂️ 리뷰노트

타임아웃 값(5초)은 임의로 설정한 값이라 팀 기준에 맞게 조정이 필요하면 말씀해주세요.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`) - 해당 없음
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

기존 테스트 전체 통과 확인하였습니다 (`npx jest`).
